### PR TITLE
Fix meta-data `glightbox: false` being ignored in on_post_page

### DIFF
--- a/mkdocs_glightbox/plugin.py
+++ b/mkdocs_glightbox/plugin.py
@@ -32,6 +32,10 @@ class LightboxPlugin(BasePlugin):
 
     def on_post_page(self, output, page, config, **kwargs):
         """ Add css link tag, javascript script tag, and javascript code to initialize GLightbox """
+        # skip page with meta glightbox is false
+        if "glightbox" in page.meta and page.meta.get('glightbox',
+                                                      True) is False:
+            return output
 
         soup = BeautifulSoup(output, "html.parser")
 


### PR DESCRIPTION
This markdown metadata is properly ignored in `on_page_content` but not in `on_post_page`. This fix will make mkdocs build faster for projects with lots of pages that contain such metadata.