### PR TITLE
added "manual" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ GLightbox is a pure javascript lightbox library with mobile support.
            caption_position: bottom
            background: white
            shadow: true
+           manual: false
     ```
 
     | Option | Default | Description |
@@ -70,6 +71,7 @@ GLightbox is a pure javascript lightbox library with mobile support.
     | caption_position | bottom | Default captions position. (bottom, top, left, right) |
     | background | white | The background CSS of lightbox image. The background will shown when the image is transparent. You can use any CSS value for the background for example `#74b9ff` or `Gainsboro` or `none` for nothing. |
     | shadow | true | Enable or disable the shadow of lightbox image. Disable it when the background is `none` to prevent shadow around the transparent image. |
+    | manual | false | When true, lightbox has to be enabled for each image manually by adding 'on-glb' class to it. |
 
     Check more options information on [GLightbox Docs](https://github.com/biati-digital/glightbox#lightbox-options).
 

--- a/demo-mkdocs/docs/index.md
+++ b/demo-mkdocs/docs/index.md
@@ -51,6 +51,7 @@ GLightbox is a pure javascript lightbox library with mobile support.
            caption_position: bottom
            background: white
            shadow: true
+           manual: false
     ```
 
     | Option | Default | Description |
@@ -68,6 +69,7 @@ GLightbox is a pure javascript lightbox library with mobile support.
     | caption_position | bottom | Default captions position. (bottom, top, left, right) |
     | background | white | The background CSS of lightbox image. The background will shown when the image is transparent. You can use any CSS value for the background for example `#74b9ff` or `Gainsboro` or `none` for nothing. |
     | shadow | true | Enable or disable the shadow of lightbox image. Disable it when the background is `none` to prevent shadow around the transparent image. |
+    | manual | false | When true, lightbox has to be enabled for each image manually by adding 'on-glb' class to it. |
 
     Check more options information on [GLightbox Docs](https://github.com/biati-digital/glightbox#lightbox-options).
 

--- a/mkdocs_glightbox/plugin.py
+++ b/mkdocs_glightbox/plugin.py
@@ -34,6 +34,7 @@ class LightboxPlugin(BasePlugin):
         ),
         ("background", config_options.Type(str, default="white")),
         ("shadow", config_options.Type(bool, default=True)),
+        ("manual", config_options.Type(bool, default=False)),
     )
 
     def on_config(self, config):
@@ -146,7 +147,7 @@ class LightboxPlugin(BasePlugin):
             classes = re.findall(r'class="([^"]+)"', img_attr)
             classes = [c for match in classes for c in match.split()]
 
-            if meta.get("glightbox-manual", False):
+            if meta.get("glightbox-manual", False) or self.config["manual"]:
                 if "on-glb" not in classes:
                     return img_tag
             else:

--- a/schema.json
+++ b/schema.json
@@ -104,6 +104,12 @@
                 "markdownDescription": "https://blueswen.github.io/mkdocs-glightbox/#usage",
                 "type": "boolean",
                 "default": true
+              },
+              "manual": {
+                "title": "When true, lightbox has to be enabled for each image manually by adding 'on-glb' class to it",
+                "markdownDescription": "https://blueswen.github.io/mkdocs-glightbox/#usage",
+                "type": "boolean",
+                "default": false
               }
             },
             "additionalProperties": false

--- a/tests/fixtures/docs/manual.md
+++ b/tests/fixtures/docs/manual.md
@@ -1,0 +1,1 @@
+![image](img.png){ .on-glb }

--- a/tests/fixtures/mkdocs-manual.yml
+++ b/tests/fixtures/mkdocs-manual.yml
@@ -1,0 +1,9 @@
+site_name: test mkdocs_glightbox
+use_directory_urls: true
+
+markdown_extensions:
+  - attr_list
+
+plugins:
+    - glightbox:
+        manual: true

--- a/tests/fixtures/mkdocs-options.yml
+++ b/tests/fixtures/mkdocs-options.yml
@@ -15,3 +15,4 @@ plugins:
         auto_caption: true
         background: none
         shadow: false
+        manual: false

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -663,3 +663,31 @@ def test_enable_by_image(tmp_path):
         rf'<a class="glightbox".*?href="{re.escape(path)}img\.png".*?><img.*?class="on-glb".*?src="{re.escape(path)}img\.png".*?\/><\/a>',
         contents,
     )
+
+
+def test_manual(tmp_path):
+    """
+    Manual mode
+    """
+    mkdocs_file = "mkdocs-manual.yml"
+    testproject_path = validate_mkdocs_file(tmp_path, f"tests/fixtures/{mkdocs_file}")
+    file = testproject_path / "site/index.html"
+    contents = file.read_text(encoding="utf8")
+    validate_static(contents)
+    validate_script(contents)
+    assert (
+        re.search(
+            r'<a class="glightbox".*?href="img\.png".*?>\s*<img.*?src="img\.png".*?\/><\/a>',
+            contents,
+        )
+        is None
+    )
+
+    file = testproject_path / "site/manual/index.html"
+    contents = file.read_text(encoding="utf8")
+    validate_static(contents, path="../")
+    validate_script(contents)
+    assert re.search(
+        r'<a class="glightbox".*?href="..\/img\.png".*?>\s*<img.*?src="..\/img\.png".*?\/><\/a>',
+        contents,
+    )


### PR DESCRIPTION
Hi and thanks for this project!

I needed to disable lightbox by default and only enable it manually on very few images in my documentation. Currently it's possible only by setting [glightbox-manual: true](https://blueswen.github.io/mkdocs-glightbox/disable/manual/) in each page's metadata. I prefer to set it globally for the whole site.

I didn't write any automatic test for it as this change seems to be quite simple.

Please, let me know what you think and if it fits the project well.

Cheers,
Michal