### PR TITLE
Allow calling lightbox methods from other places

### DIFF
--- a/mkdocs_glightbox/plugin.py
+++ b/mkdocs_glightbox/plugin.py
@@ -100,12 +100,12 @@ class LightboxPlugin(BasePlugin):
     element.setAttribute('href', imgSrc);
 });
 """
-        js_code += f"const lightbox = GLightbox({json.dumps(lb_config)});"
+        js_code += f"const lightbox = GLightbox({json.dumps(lb_config)});\n"
         if self.using_material or "navigation.instant" in config["theme"]._vars.get(
             "features", []
         ):
             # support compatible with mkdocs-material Instant loading feature
-            js_code = "document$.subscribe(() => {" + js_code + "})"
+            js_code += "document$.subscribe(() => { lightbox.reload() });\n"
         output = body_regex.sub(f"<body\\1<script>{js_code}</script></body>", output)
 
         return output

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -183,7 +183,7 @@ def test_material(tmp_path):
     validate_static(contents)
     validate_script(contents)
     assert re.search(
-        r"document\$\.subscribe\(\(\) => {const lightbox = GLightbox\((.*)\);}\)",
+        r"document\$\.subscribe\(\(\) => { lightbox.reload\(\) }\);",
         contents,
     )
     assert re.search(
@@ -518,7 +518,7 @@ def test_material_template(tmp_path):
     validate_static(contents)
     validate_script(contents)
     assert re.search(
-        r"document\$\.subscribe\(\(\) => {const lightbox = GLightbox\((.*)\);}\)",
+        r"document\$\.subscribe\(\(\) => { lightbox.reload\(\) }\);",
         contents,
     )
     assert re.search(


### PR DESCRIPTION
When using mkdocs-material or instant navigation, plugin injects a script that looks like this:
```
document$.subscribe(() => { const lightbox = GLightbox(...); });
```
Instead, I suggest to insert this, making the `lightbox` variable accessible from outside:
```
const lightbox = GLightbox(...);
document$.subscribe(() => { lightbox.reload() });
```
This makes possible to call [various methods](https://github.com/biati-digital/glightbox#methods) of the lightbox instance from other JS scripts.