### PR TITLE
add id to appended script tag

### DIFF
--- a/mkdocs_glightbox/plugin.py
+++ b/mkdocs_glightbox/plugin.py
@@ -106,7 +106,7 @@ class LightboxPlugin(BasePlugin):
         ):
             # support compatible with mkdocs-material Instant loading feature
             js_code = "document$.subscribe(() => {" + js_code + "})"
-        output = body_regex.sub(f"<body\\1<script>{js_code}</script></body>", output)
+        output = body_regex.sub(f'<body\\1<script id="init-glightbox">{js_code}</script></body>', output)
 
         return output
 


### PR DESCRIPTION
We've had an [issue](https://github.com/unverbuggt/mkdocs-encryptcontent-plugin/issues/62) where glightbox didn't work after decryption at first (if the decryption key was available on the second run it worked).

The encryptcontent plugin fixes some other mkdocs plugins by re-calling their initialization after successful decryption. In order to be able to do that with glightbox, we need to have a script id.