### PR TITLE
feat: Support the `#only-dark` and `#only-light` feature of mkdocs-material by setting the `data-gallery` attribute

### DIFF
--- a/mkdocs_glightbox/plugin.py
+++ b/mkdocs_glightbox/plugin.py
@@ -122,9 +122,9 @@ class LightboxPlugin(BasePlugin):
 
         return output
 
-    def on_page_markdown(self, markdown, *args, **kwargs):
+    def on_page_markdown(self, markdown, page, config, files, **kwargs):
         """Support the #only-dark feature by setting the data-gallery property"""
-        if not self.config["auto_themed"]:
+        if not self.config["auto_themed"] or not page.meta.get("glightbox.auto_themed", True):
             return markdown
 
         def repl_md(match):

--- a/mkdocs_glightbox/plugin.py
+++ b/mkdocs_glightbox/plugin.py
@@ -27,6 +27,7 @@ class LightboxPlugin(BasePlugin):
         ("zoomable", config_options.Type(bool, default=True)),
         ("draggable", config_options.Type(bool, default=True)),
         ("skip_classes", config_options.Type(list, default=[])),
+        ("auto_themed", config_options.Type(bool, default=False)),
         ("auto_caption", config_options.Type(bool, default=False)),
         (
             "caption_position",
@@ -120,6 +121,32 @@ class LightboxPlugin(BasePlugin):
         )
 
         return output
+
+    def on_page_markdown(self, markdown, *args, **kwargs):
+        """Support the #only-dark feature by setting the data-gallery property"""
+        if not self.config["auto_themed"]:
+            return markdown
+
+        def repl_md(match):
+            md = match.group()
+            if "#only-light" in md or "#gh-light-mode-only" in md:
+                return md + "{data-gallery='light'}"
+            elif "#only-dark" in md or "#gh-dark-mode-only" in md:
+                return md + "{data-gallery='dark'}"
+            return md
+
+        def repl_html(match):
+            html = match.group()
+            if "#only-light" in html or "#gh-light-mode-only" in html:
+                return f'{html[:4]} data-gallery="light" {html[4:]}'
+            elif "#only-dark" in html or "#gh-dark-mode-only" in html:
+                return f'{html[:4]} data-gallery="dark" {html[4:]}'
+            return html
+
+        markdown = re.sub("!\\[[^\\]]*\\]\\([^)]*\\)", repl_md, markdown)
+        markdown = re.sub("<img.*>", repl_html, markdown)
+
+        return markdown
 
     def on_page_content(self, html, page, config, **kwargs):
         """Wrap img tag with anchor tag with glightbox class and attributes from config"""


### PR DESCRIPTION
feat: #26 

I've added a configuration option called `auto_themed`, which defaults to `False`. Set it to `True` to support the `#only-dark` and `#only-light` feature of [mkdocs material](https://squidfunk.github.io/mkdocs-material/reference/images/#light-and-dark-mode).

Support both `![]()` and `<img>` formats.

**How it works?**

According to https://blueswen.github.io/mkdocs-glightbox/gallery/gallery/, we can solve this problem by inserting the `data-gallery` attribute depending on whether the image element contains a special fragment(e.g `#only-dark`) or not.

Supported fragments are: `#only-dark`, `#only-light`, `#gh-dark-mode-only` and `#gh-light-mode-only`.