### PR TITLE
Fix theme config dictionary handling

### DIFF
--- a/mkdocs_glightbox/plugin.py
+++ b/mkdocs_glightbox/plugin.py
@@ -123,9 +123,7 @@ class LightboxPlugin(BasePlugin):
 });
 """
         js_code += "const lightbox = GLightbox(" + json.dumps(lb) + ");\n"
-        if self.using_material or "navigation.instant" in config["theme"].get(
-            "features", []
-        ):
+        if self.using_material or ("features" in config["theme"] and "navigation.instant" in config["theme"]["features"]):
             js_code += "document$.subscribe(()=>{ lightbox.reload(); });\n"
 
         init_js_node = create_tag("script")


### PR DESCRIPTION
Theme object for configuration dictionary does not implement .get() but does allow lookup by key. Without this change, a mkdocs build on a readthedocs project would fail with an exception.